### PR TITLE
Update README* to replace sudo su with sudo -iu

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -132,7 +132,7 @@ Misskeyのソースは`/home/ユーザー/ディレクトリ`としてcloneさ�
 Misskeyディレクトリへは、以下のように移動するとよいでしょう。
 
 ```
-sudo su - ユーザー
+sudo -iu ユーザー
 cd ディレクトリ
 ```
 
@@ -161,10 +161,10 @@ journalctl -t example.com
 ### Docker
 DockerはMisskeyユーザーでrootless実行されています。
 
-sudo suでMisskeyユーザーに入るときは、`XDG_RUNTIME_DIR`と`DOCKER_HOST`を変更する必要があります。
+sudo でMisskeyユーザーに入るときは、`XDG_RUNTIME_DIR`と`DOCKER_HOST`を変更する必要があります。
 
 ```
-sudo su - ユーザー
+sudo -iu ユーザー
 export XDG_RUNTIME_DIR=/run/user/$UID
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Misskeyのソースは`/home/ユーザー/ディレクトリ`としてcloneさ�
 Misskeyディレクトリへは、以下のように移動するとよいでしょう。
 
 ```
-sudo su - ユーザー
+sudo -iu ユーザー
 cd ディレクトリ
 ```
 
@@ -165,10 +165,10 @@ journalctl -t example.com
 ### Docker
 DockerはMisskeyユーザーでrootless実行されています。
 
-sudo suでMisskeyユーザーに入るときは、`XDG_RUNTIME_DIR`と`DOCKER_HOST`を変更する必要があります。
+sudo でMisskeyユーザーに入るときは、`XDG_RUNTIME_DIR`と`DOCKER_HOST`を変更する必要があります。
 
 ```
-sudo su - ユーザー
+sudo -iu ユーザー
 export XDG_RUNTIME_DIR=/run/user/$UID
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
 


### PR DESCRIPTION
This change is made to replace _sudo su_ usage with the more elegant `sudo -iu`.
_sudo su_ hijacks `su`, by calling it with root privileges. This is bad quality and should not be used.
`sudo` itself does provide a feature to launch a login shell as specified user `-i`[[1]](https://man.archlinux.org/man/sudo.8#i), In this case combined with `-u`[[2]](https://man.archlinux.org/man/sudo.8#u) to call the user instead of root.

For more explanation also see explainshell [sudo -iu ユーザー [3]](https://explainshell.com/explain?cmd=sudo+-i+-u+%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC) vs [sudo su - ユーザー [4]](https://explainshell.com/explain?cmd=sudo+su+-+%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC)

¹ https://man.archlinux.org/man/sudo.8#i
² https://man.archlinux.org/man/sudo.8#u
³ https://explainshell.com/explain?cmd=sudo+-i+-u+%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC
⁴ https://explainshell.com/explain?cmd=sudo+su+-+%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC