### PR TITLE
feat: use misskey default maxFileSize for nginx config

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -687,7 +687,7 @@ echo "Process: add nginx config;"
 tput setaf 7;
 cat >> "/etc/nginx/conf.d/$host.conf" << NGEOF
     # Change to your upload limit
-    client_max_body_size 80m;
+    client_max_body_size 250m;
 
     # Proxy to Node
     location / {


### PR DESCRIPTION
resolves #22 

---

# Summary

- When creating the Nginx config, the `client_max_body_size` is 80MB. However, Misskey defaults to a 250MB upload limit. Perhaps it's worth changing the config generation to match the Misskey defaults.

https://github.com/joinmisskey/bash-install/blob/692a60449e52d3f20de567af41bb78307bffb4cf/ubuntu.sh#L690

- See [`misskey/.config/example.yml`](https://github.com/misskey-dev/misskey/blob/8866c530c41fe4144a72b0c4190362b6249b2629/.config/example.yml#L217-L218C2). and the [`misskey/../DownloadService.ts`](https://github.com/misskey-dev/misskey/blob/8866c530c41fe4144a72b0c4190362b6249b2629/packages/backend/src/core/DownloadService.ts#L43-L45) using default values.



