### PR TITLE
fix: update script is broken with pnpm 11

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -856,8 +856,15 @@ fi
 if [ $method == "systemd" ]; then
 #region systemd
 #region work with misskey user
-su "$misskey_user" << MKEOF;
+# Save the TTY to fd3 and restore it with `exec <&3` in the subshell
+# to let commands work in an interactive environment and prevent future problems.
+# We need to restore the TTY as stdin in the subshell because running
+# `exec <&3` in the outer shell would make bash read commands from the
+# TTY instead of the heredoc.
+su "$misskey_user" 3<&0 << MKEOF
+{
 set -eu;
+exec <&3;
 cd ~
 cd "$misskey_directory";
 
@@ -885,6 +892,7 @@ else
 	tput setaf 1;
 	echo "	NG.";
 fi
+}
 MKEOF
 #endregion
 

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -867,6 +867,7 @@ set -eu;
 exec <&3;
 cd ~
 cd "$misskey_directory";
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 tput setaf 3;
 echo "Process: install npm packages;"
@@ -892,6 +893,7 @@ else
 	tput setaf 1;
 	echo "	NG.";
 fi
+exit;
 }
 MKEOF
 #endregion

--- a/update.ubuntu.sh
+++ b/update.ubuntu.sh
@@ -83,14 +83,22 @@ tput setaf 7;
 systemctl stop "$host"
 
 #region work with misskey user
-su "$misskey_user" << MKEOF
+# Save the TTY to fd3 and restore it with `exec <&3` in the subshell
+# to let commands work in an interactive environment and prevent future problems.
+# We need to restore the TTY as stdin in the subshell because running
+# `exec <&3` in the outer shell would make bash read commands from the
+# TTY instead of the heredoc.
+su "$misskey_user" 3<&0 << MKEOF
+{
 set -eu;
+exec <&3;
 cd ~/$misskey_directory;
 
 tput setaf 3;
 echo "Process: clean;";
 tput setaf 7;
-pnpm run clean;
+# since we're cleaning built dir, verifyDepsBeforeRun is not necessary. pnpm clean can be overridden by npm scripts
+PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run clean;
 
 tput setaf 3;
 echo "Process: pnpm install;";
@@ -106,6 +114,7 @@ tput setaf 3;
 echo "Process: migrate db;";
 tput setaf 7;
 NODE_OPTIONS=--max_old_space_size=3072 pnpm run migrate;
+}
 MKEOF
 #endregion
 

--- a/update.ubuntu.sh
+++ b/update.ubuntu.sh
@@ -93,6 +93,7 @@ su "$misskey_user" 3<&0 << MKEOF
 set -eu;
 exec <&3;
 cd ~/$misskey_directory;
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 tput setaf 3;
 echo "Process: pnpm install;";
@@ -114,6 +115,7 @@ tput setaf 3;
 echo "Process: migrate db;";
 tput setaf 7;
 NODE_OPTIONS=--max_old_space_size=3072 pnpm run migrate;
+exit;
 }
 MKEOF
 #endregion

--- a/update.ubuntu.sh
+++ b/update.ubuntu.sh
@@ -95,15 +95,15 @@ exec <&3;
 cd ~/$misskey_directory;
 
 tput setaf 3;
+echo "Process: pnpm install;";
+tput setaf 7;
+NODE_ENV=production pnpm install --frozen-lockfile;
+
+tput setaf 3;
 echo "Process: clean;";
 tput setaf 7;
 # since we're cleaning built dir, verifyDepsBeforeRun is not necessary. pnpm clean can be overridden by npm scripts
 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run clean;
-
-tput setaf 3;
-echo "Process: pnpm install;";
-tput setaf 7;
-NODE_ENV=production pnpm install --frozen-lockfile;
 
 tput setaf 3;
 echo "Process: build misskey;";


### PR DESCRIPTION
updateスクリプトが pnpm 11 の `verifyDepsBeforeRun` 関連 braking changes と pnpm 10.16 の `ABORTED_REMOVE_MODULES_DIR_NO_TTY` 関連の変更に影響を受けて 2026.5.2 以降へ更新ができない問題を修正します。