### PR TITLE
fix(v4): improve TTY handling in misskey installation scripts

### DIFF
--- a/misskey-install.sh
+++ b/misskey-install.sh
@@ -1530,10 +1530,18 @@ function install() {
 
         #Setup misskey
         tput setaf 3; echo "Process: setup misskey"; tput setaf 7;
-        sudo -iu "$misskey_user" <<-EOF;
+        # Save the TTY to fd3 and restore it with `exec <&3` in the subshell
+        # to let commands work in an interactive environment and prevent future problems.
+        # We need to restore the TTY as stdin in the subshell because running
+        # `exec <&3` in the outer shell would make bash read commands from the
+        # TTY instead of the heredoc.
+        sudo -iu "$misskey_user" 3<&0 <<-EOF;
+		{
 		set -eu;
+		exec <&3;
 		cd ~;
 		cd "$misskey_directory";
+		export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 		tput setaf 3; echo "Process: install npm packages"; tput setaf 7;
 		NODE_ENV=production pnpm install --frozen-lockfile;
@@ -1550,6 +1558,8 @@ function install() {
 		else
 			tput setaf 1; echo "	NG.";
 		fi
+		exit;
+		}
 		EOF
 
         #Create misskey daemon

--- a/update.ubuntu.sh
+++ b/update.ubuntu.sh
@@ -82,19 +82,28 @@ tput setaf 7;
 systemctl stop "$host"
 
 #region work with misskey user
-su "$misskey_user" << MKEOF
+# Save the TTY to fd3 and restore it with `exec <&3` in the subshell
+# to let commands work in an interactive environment and prevent future problems.
+# We need to restore the TTY as stdin in the subshell because running
+# `exec <&3` in the outer shell would make bash read commands from the
+# TTY instead of the heredoc.
+su "$misskey_user" 3<&0 << MKEOF
+{
 set -eu;
+exec <&3;
 cd ~/$misskey_directory;
-
-tput setaf 3;
-echo "Process: clean;";
-tput setaf 7;
-pnpm run clean;
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 tput setaf 3;
 echo "Process: pnpm install;";
 tput setaf 7;
 NODE_ENV=production pnpm install --frozen-lockfile;
+
+tput setaf 3;
+echo "Process: clean;";
+tput setaf 7;
+# since we're cleaning built dir, verifyDepsBeforeRun is not necessary. pnpm clean can be overridden by npm scripts
+PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run clean;
 
 tput setaf 3;
 echo "Process: build misskey;";
@@ -105,6 +114,8 @@ tput setaf 3;
 echo "Process: migrate db;";
 tput setaf 7;
 NODE_OPTIONS=--max_old_space_size=3072 pnpm run migrate;
+exit;
+}
 MKEOF
 #endregion
 


### PR DESCRIPTION
https://github.com/joinmisskey/bash-install/pull/35 の内容をv4ブランチにも反映します。
misskey-tga経由で利用されるのはmainブランチのスクリプトではなく、v4ブランチのものであるため…