### PR TITLE
fix: use login shell for su command in installation scripts

### DIFF
--- a/misskey-install.sh
+++ b/misskey-install.sh
@@ -1536,7 +1536,7 @@ function install() {
         # We need to restore the TTY as stdin in the subshell because running
         # `exec <&3` in the outer shell would make bash read commands from the
         # TTY instead of the heredoc.
-        su "$misskey_user" 3<&0 <<-EOF
+        su - "$misskey_user" 3<&0 <<-EOF
 		{
 		set -eu;
 		exec <&3;

--- a/update.ubuntu.sh
+++ b/update.ubuntu.sh
@@ -64,7 +64,7 @@ tput setaf 3;
 echo "Process: update (systemd);";
 tput setaf 7;
 #region work with misskey user
-su "$misskey_user" << MKEOF
+su - "$misskey_user" << MKEOF
 set -eu;
 cd ~/$misskey_directory;
 
@@ -87,7 +87,7 @@ systemctl stop "$host"
 # We need to restore the TTY as stdin in the subshell because running
 # `exec <&3` in the outer shell would make bash read commands from the
 # TTY instead of the heredoc.
-su "$misskey_user" 3<&0 << MKEOF
+su - "$misskey_user" 3<&0 << MKEOF
 {
 set -eu;
 exec <&3;


### PR DESCRIPTION
https://github.com/joinmisskey/bash-install/pull/37 のfollowupです。

Error:  EACCES: permission denied, open '/home/runner/.config/pnpm/config.yaml'
という当初のエラーを解決するため…

直接の原因としては、環境変数の汚染とpnpm v11の挙動変更が組み合わさったためのようでした。

- 本来は`su -`で呼ばないといけない所、ハイフンを付け忘れていた
- $XDG_CONFIG_HOMEもしくは$HOME/.configを読みに行く
- $misskey_userとシェル実行ユーザが異なる

上記が合わさり、「runnerユーザのホームディレクトリを$HOMEに持ったまま$misskey_userでpnpmを起動し、pnpmが/home/runner/.configを見に行こうとして権限エラー」という動きをしたのが上記のログだと思います（本当は/home/$misskey_user/.configを見に行きたい）