### PR TITLE
fix: unset XDG_CONFIG_HOME to address GitHub Actions constraints

### DIFF
--- a/misskey-install.sh
+++ b/misskey-install.sh
@@ -25,6 +25,12 @@
 version="4.0.0-beta.2";
 NODE_MAJOR="22";
 
+# GitHub Actions 側の制約により、sudo/su で別ユーザーに切り替えても
+# runner ユーザーの XDG_CONFIG_HOME が残ることがある。
+# https://github.com/actions/runner-images/issues/13049
+# Git/pnpm などが /home/runner/.config を読みに行かないようにする。
+unset XDG_CONFIG_HOME;
+
 #About this script
 tput setaf 4;
 echo "";

--- a/update.ubuntu.sh
+++ b/update.ubuntu.sh
@@ -20,6 +20,12 @@
 #
 version="3.2.1";
 
+# GitHub Actions 側の制約により、sudo/su で別ユーザーに切り替えても
+# runner ユーザーの XDG_CONFIG_HOME が残ることがある。
+# https://github.com/actions/runner-images/issues/13049
+# Git/pnpm などが /home/runner/.config を読みに行かないようにする。
+unset XDG_CONFIG_HOME;
+
 tput setaf 2;
 echo "Check: root user;";
 if [ "$(whoami)" != 'root' ]; then


### PR DESCRIPTION
#38 のfollowupです。
su -で環境変数の引継ぎを辞めても改善しなかったため…

https://github.com/actions/runner-images/issues/13049
上記を見る限り、どうやらXDG_CONFIG_HOMEは/home/runnerに固定されているようです。
なので、ワークフローの途中でユーザを切り替える場合＋XDG_CONFIG_HOMEを読むツールを使う場合は、同変数を消すか書き換えるかをする必要がありました。

pnpmも例にもれず、XDG_CONFIG_HOMEからconfigのパスを解決する動きがv11から強くなったので顕在化したものと思われます。今回はXDG_CONFIG_HOMEを使わず`~/.config/pnpm/config.yaml`にフォールバックしてほしいので、環境変数を消す対応を取りました。

参考：
https://pnpm.io/cli/config